### PR TITLE
Fix `DOI` in `powerly-package.R`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: powerly
 Title: Sample Size Analysis for Psychological Networks and More
-Version: 1.9.1
+Version: 1.9.2
 Authors@R:
     person(given = "Mihai",
            family = "Constantin",

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file. The format
 is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.9.2
+### Fixed
+- Remove `\doi{}` call from `powerly-package.R` documentation.
+
 ## 1.9.1
 ### Fixed
 - Fix incorrect `DOI` in `powerly-package.R` documentation.

--- a/R/powerly-package.R
+++ b/R/powerly-package.R
@@ -41,8 +41,8 @@
 #'
 #' @description
 #' `powerly` is a package that implements the method by [Constantin et al.
-#' (2023)](\doi{10.1037/met0000555}) for conducting sample size analysis for
-#' network models.
+#' (2023)](https://doi.org/10.1037/met0000555) for conducting sample size
+#' analysis for network models.
 #'
 #' @details
 #' The method implemented is implemented in the main function [powerly()]. The

--- a/man/powerly-package.Rd
+++ b/man/powerly-package.Rd
@@ -5,8 +5,8 @@
 \alias{powerly-package}
 \title{Sample Size Analysis for Psychological Networks and More}
 \description{
-\code{powerly} is a package that implements the method by \href{\doi{10.1037/met0000555}}{Constantin et al. (2023)} for conducting sample size analysis for
-network models.
+\code{powerly} is a package that implements the method by \href{https://doi.org/10.1037/met0000555}{Constantin et al. (2023)} for conducting sample size
+analysis for network models.
 }
 \details{
 The method implemented is implemented in the main function \code{\link[=powerly]{powerly()}}. The


### PR DESCRIPTION
- Overlooked the fact that the `\doi` call got wrapped by `\href`. Removed `\doi` called altogether.
- Prepared files for patch release `v1.9.2`.