### PR TITLE
Fix `DOI` note on `CRAN`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: powerly
 Title: Sample Size Analysis for Psychological Networks and More
-Version: 1.9.2
+Version: 1.9.3
 Authors@R:
     person(given = "Mihai",
            family = "Constantin",

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file. The format
 is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.9.3
+### Fixed
+- Add `\doi{}` call to `powerly-package.R` documentation. I know what you're
+  thinking...
+
 ## 1.9.2
 ### Fixed
 - Remove `\doi{}` call from `powerly-package.R` documentation.

--- a/R/powerly-package.R
+++ b/R/powerly-package.R
@@ -40,9 +40,9 @@
 #' Sample Size Analysis for Psychological Networks and More
 #'
 #' @description
-#' `powerly` is a package that implements the method by [Constantin et al.
-#' (2023)](https://doi.org/10.1037/met0000555) for conducting sample size
-#' analysis for network models.
+#' `powerly` is a package that implements the method by Constantin et al. (2023;
+#' see \doi{10.1037/met0000555}) for conducting sample size analysis for network
+#' models.
 #'
 #' @details
 #' The method implemented is implemented in the main function [powerly()]. The

--- a/man/powerly-package.Rd
+++ b/man/powerly-package.Rd
@@ -5,8 +5,9 @@
 \alias{powerly-package}
 \title{Sample Size Analysis for Psychological Networks and More}
 \description{
-\code{powerly} is a package that implements the method by \href{https://doi.org/10.1037/met0000555}{Constantin et al. (2023)} for conducting sample size
-analysis for network models.
+\code{powerly} is a package that implements the method by Constantin et al. (2023;
+see \doi{10.1037/met0000555}) for conducting sample size analysis for network
+models.
 }
 \details{
 The method implemented is implemented in the main function \code{\link[=powerly]{powerly()}}. The


### PR DESCRIPTION
- This time I added back the `\doi` macro call and simply not used it as a link for the authors' names.